### PR TITLE
[yi-hack-support] Fix issue last_file not found

### DIFF
--- a/yi-hack-support/sd/test/scripts/upload_to_ftp.sh
+++ b/yi-hack-support/sd/test/scripts/upload_to_ftp.sh
@@ -145,8 +145,8 @@ is_leap_year()
 
 main()
 {
-   last_folder = ""
-   last_file = ""
+   last_folder=""
+   last_file=""
 
    # Here we goooooo!
    is_server_live $ftp_host


### PR DESCRIPTION
There is a bug in variable declaration in shell script.
Should not have space between variable name, '=' and value
