### PR TITLE
yi-hack-support: fix last uploaded file is not stored in ftp_upload.mem

### DIFF
--- a/yi-hack-support/sd/test/scripts/upload_to_ftp.sh
+++ b/yi-hack-support/sd/test/scripts/upload_to_ftp.sh
@@ -68,7 +68,7 @@ mem_store()
 {
    last_folder=$1
    last_file=$2
-   echo "${last_folder}/${last_file}" > ${1-"$ftp_mem_file"}
+   echo "${last_folder}/${last_file}" > ${3-"$ftp_mem_file"}
 }
 
 mem_get()


### PR DESCRIPTION
Fix the issue that last uploaded file is not stored in ftp_upload.mem
